### PR TITLE
Security update - CVE-2017-18342

### DIFF
--- a/src/server/web/requirements.txt
+++ b/src/server/web/requirements.txt
@@ -1,6 +1,6 @@
 flask==0.10.1
 markdown==2.3.1
-pyyaml==3.10
+pyyaml>=4.2b1
 waitress==0.8.5
 Werkzeug==0.12.2
 pyOpenSSL==0.14


### PR DESCRIPTION
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.