### PR TITLE
[cassh] v1.6.2 : no-LDAP fixes

### DIFF
--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -4,6 +4,27 @@ CHANGELOG
 CASSH Client
 -----
 
+1.6.2
+-----
+
+2019/05/23
+
+### Bug Fixes
+
+  - fix "Error: No realname option given." : LDAP can be disable/enable
+
+
+1.6.1
+-----
+
+2019/05/22
+
+### Other
+
+  - Reorder directories
+  - Update tests and README
+
+
 1.6.0
 -----
 

--- a/src/client/cassh
+++ b/src/client/cassh
@@ -21,7 +21,7 @@ from requests.exceptions import ConnectionError
 # Debug
 # from pdb import set_trace as st
 
-VERSION = '%(prog)s 1.6.0'
+VERSION = '%(prog)s 1.6.2'
 
 def print_result(result):
     """ Display result """
@@ -79,6 +79,13 @@ def read_conf(conf_path):
     except NoSectionError:
         user_metadata['auth'] = None
         user_metadata['realname'] = None
+
+    try:
+        user_metadata['ldap_enable'] = bool(config.get('ldap', 'enable') != 'False')
+    except NoOptionError:
+        user_metadata['ldap_enable'] = True
+    except NoSectionError:
+        user_metadata['ldap_enable'] = False
 
     if not isfile(user_metadata['key_path']):
         print('File %s doesn\'t exists' % user_metadata['key_path'])
@@ -193,8 +200,10 @@ class CASSH(object):
         """
         data = {}
         passwd_message = 'Please type your LDAP password (user=%s): ' % self.realname
+        if self.user_metadata['ldap_enable']:
+            data.update({'password': getpass(passwd_message)})
         if self.auth == 'ldap':
-            data.update({'realname': self.realname, 'password': getpass(passwd_message)})
+            data.update({'realname': self.realname})
         if prefix is not None:
             data.update(prefix)
         return data
@@ -374,6 +383,7 @@ if __name__ == '__main__':
         print('[ldap]')
         print('# realname : this is the LDAP/AD login user')
         print('realname = ursula.ser@domain.fr')
+        print('enable = True')
         exit(1)
 
     CLIENT = CASSH(read_conf(CONF_FILE))

--- a/src/client/cassh-client.conf
+++ b/src/client/cassh-client.conf
@@ -11,3 +11,4 @@ url = http://cassh-server:8080
 
 [ldap]
 realname = user@test.fr
+enable = True


### PR DESCRIPTION
CASSH Client
-----

1.6.2
-----

2019/05/23

### Bug Fixes

  - fix "Error: No realname option given." : LDAP can be disable/enable


1.6.1
-----

2019/05/22

### Other

  - Reorder directories
  - Update tests and README
