### PR TITLE
Cassh Server 2.0.2: Fix

### DIFF
--- a/src/server/CHANGELOG.md
+++ b/src/server/CHANGELOG.md
@@ -4,6 +4,15 @@ CHANGELOG
 CASSH Server
 -----
 
+2.0.2
+-----
+
+2020/04/09
+
+### Bug Fixes
+  - Handle custom_principals as None (old database entry)
+  - Urldecode 'add' parameter
+
 2.0.1
 -----
 
@@ -11,7 +20,6 @@ CASSH Server
 
 ### Bug Fixes
   - Unblock no-membership/no-bindCN user with a valid login/password
-
 
 2.0.0
 -----

--- a/src/server/lib/tools.py
+++ b/src/server/lib/tools.py
@@ -270,7 +270,7 @@ def validate_payload(key, value):
     new_value = unquote_plus(value)
     count = 10
     while value != new_value and count > 0 and \
-        key in ['username', 'principals', 'remove', 'update', 'filter', 'realname']:
+        key in ['username', 'principals', 'add', 'remove', 'update', 'filter', 'realname']:
         value = new_value
         new_value = unquote_plus(value)
         count -= 1
@@ -327,6 +327,8 @@ def truncate_principals(custom_principals, list_membership, server_options):
     """
     Returns custom_principals without LDAP principals
     """
+    if not custom_principals:
+        return ''
     principals = custom_principals.split(',')
     if not server_options['ldap_mapping']:
         return ','.join(principals)
@@ -351,6 +353,8 @@ def merge_principals(custom_principals, list_membership, server_options):
     """
     Returns a custom_principals + LDAP principals
     """
+    if not custom_principals:
+        return ''
     principals = custom_principals.split(',')
     if not server_options['ldap_mapping']:
         return ','.join(principals)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -29,7 +29,7 @@ import lib.tools as tools
 # DEBUG
 # from pdb import set_trace as st
 
-VERSION = '2.0.1'
+VERSION = '2.0.2'
 
 SERVER_OPTS, ARGS, TOOLS = tools.loadconfig(version=VERSION)
 


### PR DESCRIPTION
CASSH Server
-----

2.0.2
-----

2020/04/09

### Bug Fixes
  - Handle custom_principals as None (old database entry)
  - Urldecode 'add' parameter