### PR TITLE
Upgrade Cassh Client/Server/WebUI

### DIFF
--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -4,10 +4,22 @@ CHANGELOG
 CASSH Client
 -----
 
+1.8.0
+-----
+
+2021/05/10
+
+### Changes
+  - `expiry` do not require a `+`
+
+### Fix
+  - Fix `expiry` crash (@fedegiova)
+
+
 1.7.0
 -----
 
-2020/01/24
+2020/04/24
 
 ### New Features
 

--- a/src/client/cassh
+++ b/src/client/cassh
@@ -3,7 +3,7 @@
 """
 CASSH CLI
 
-Copyright 2017 Nicolas BEGUIER
+Copyright 2017-2021 Nicolas BEGUIER
 Licensed under the Apache License, Version 2.0
 Written by Nicolas BEGUIER (nicolas_beguier@hotmail.com)
 
@@ -29,7 +29,7 @@ from requests.exceptions import ConnectionError
 # Debug
 # from pdb import set_trace as st
 
-VERSION = '%(prog)s 1.7.0'
+VERSION = '%(prog)s 1.8.0'
 
 PATTERN_USERNAME = re_compile("^([a-z]+)$")
 
@@ -250,7 +250,7 @@ class CASSH(object):
         elif action == 'set':
             if set_value[0] == 'deprecated':
                 set_value_dict = {}
-                set_value_dict[set_value.split('=')[0]] = set_value.split('=')[1]
+                set_value_dict[set_value[1].split('=')[0]] = set_value[1].split('=')[1]
                 payload.update(set_value_dict)
                 req = self.patch('/admin/' + username, payload)
             else:
@@ -286,9 +286,8 @@ class CASSH(object):
         Add a public key.
         """
         payload = self.get_data()
-        pubkey = open('%s.pub' % self.key_path, 'r')
-        payload.update({'pubkey': pubkey.read()})
-        pubkey.close()
+        with open('%s.pub' % self.key_path, 'r') as pubkey:
+            payload.update({'pubkey': pubkey.read()})
         payload.update({'username': self.name})
         req = self.put('/client', payload)
         print(req.text)
@@ -298,9 +297,8 @@ class CASSH(object):
         Sign a public key.
         """
         payload = self.get_data()
-        pubkey = open('%s.pub' % self.key_path, 'r')
-        payload.update({'pubkey': pubkey.read()})
-        pubkey.close()
+        with open('%s.pub' % self.key_path, 'r') as pubkey:
+            payload.update({'pubkey': pubkey.read()})
         payload.update({'username': self.name})
         if force:
             payload.update({'admin_force': True})
@@ -312,9 +310,8 @@ class CASSH(object):
             key_signed_path = self.user_metadata['key_signed_path']
             copyfile(self.key_path, key_signed_path)
             chmod(key_signed_path, 0o600)
-            pubkey_signed = open('%s.pub' % key_signed_path, 'w+')
-            pubkey_signed.write(req.text)
-            pubkey_signed.close()
+            with open('%s.pub' % key_signed_path, 'w+') as pubkey_signed:
+                pubkey_signed.write(req.text)
             print('Public key successfuly signed')
         else:
             print(req.text)

--- a/src/server/CHANGELOG.md
+++ b/src/server/CHANGELOG.md
@@ -4,6 +4,21 @@ CHANGELOG
 CASSH Server
 -----
 
+2.2.0
+-----
+
+2021/03/26
+
+### New Features
+  - `realname` can have upper case (@fedegiova)
+
+### Changes
+  - `expiry` do not require a `+`
+
+## Lint
+  - R1732: Consider using 'with' for resource-allocating operations
+  - W1401: Anomalous backslash in string: '\d'. String constant might be missing an r prefix.
+
 2.1.1
 -----
 

--- a/src/server/lib/constants.py
+++ b/src/server/lib/constants.py
@@ -18,8 +18,8 @@ STATES = {
     'PENDING': 2,
 }
 
-PATTERN_EXPIRY = re_compile('^\\+([0-9]+)+[dh]$')
-PATTERN_PRINCIPALS = re_compile("^([a-zA-Z-\d]+)$")
+PATTERN_EXPIRY = re_compile('^([0-9]+)+[dh]$')
+PATTERN_PRINCIPALS = re_compile(r'^([a-zA-Z-\d]+)$')
 PATTERN_REALNAME = re_compile(
     r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"
     r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-011\013\014\016-\177])*"'

--- a/src/server/lib/tools.py
+++ b/src/server/lib/tools.py
@@ -2,7 +2,7 @@
 """
 tools lib
 
-Copyright 2017 Nicolas BEGUIER
+Copyright 2017-2021 Nicolas BEGUIER
 Licensed under the Apache License, Version 2.0
 Written by Nicolas BEGUIER (nicolas_beguier@hotmail.com)
 
@@ -556,9 +556,8 @@ class Tools():
                     content_type='application/octet-stream')
 
             for pubkey in pubkeys:
-                tmp_pubkey = NamedTemporaryFile(delete=False)
-                tmp_pubkey.write(bytes(pubkey[0], 'utf-8'))
-                tmp_pubkey.close()
+                with NamedTemporaryFile(delete=False) as tmp_pubkey:
+                    tmp_pubkey.write(bytes(pubkey[0], 'utf-8'))
                 ca_ssh.update_krl(tmp_pubkey.name)
             remove(tmp_pubkey.name)
 
@@ -589,7 +588,7 @@ class Tools():
         is_list = False
 
         if realname is not None:
-            cur.execute('SELECT * FROM USERS WHERE REALNAME=lower((%s))', (realname,))
+            cur.execute('SELECT * FROM USERS WHERE REALNAME=(%s)', (realname,))
             result = cur.fetchone()
         elif username is not None:
             cur.execute('SELECT * FROM USERS WHERE NAME=(%s)', (username,))
@@ -647,7 +646,7 @@ class Tools():
         # Sign the key
         try:
             cert_contents = ca_ssh.sign_public_user_key(\
-                tmp_pubkey_name, username, expiry, principals)
+                tmp_pubkey_name, username, '+'+expiry, principals)
             if db_cursor is not None:
                 db_cursor.execute('UPDATE USERS SET STATE=0, EXPIRATION=(%s) WHERE NAME=(%s)', \
                     (time() + str2date(expiry), username))

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -1,6 +1,6 @@
 configparser==5.0.0
 psycopg2-binary==2.8.4
-python-ldap==3.2.0
+python-ldap==3.4.0
 requests==2.23.0
 web.py==0.51
 wheel==0.34.2

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -29,7 +29,7 @@ import lib.tools as tools
 # DEBUG
 # from pdb import set_trace as st
 
-VERSION = '2.1.1'
+VERSION = '2.2.0'
 
 SERVER_OPTS, ARGS, TOOLS = tools.loadconfig(version=VERSION)
 
@@ -294,9 +294,8 @@ class Client():
             return tools.response_render(
                 'Error: No pubkey given.',
                 http_code='400 Bad Request')
-        tmp_pubkey = NamedTemporaryFile(delete=False)
-        tmp_pubkey.write(bytes(pubkey, 'utf-8'))
-        tmp_pubkey.close()
+        with NamedTemporaryFile(delete=False) as tmp_pubkey:
+            tmp_pubkey.write(bytes(pubkey, 'utf-8'))
 
         pubkey_fingerprint = get_fingerprint(tmp_pubkey.name)
         if pubkey_fingerprint == 'Unknown':
@@ -333,9 +332,8 @@ class Client():
                 http_code='400 Bad Request')
 
         # Get database key fingerprint
-        db_pubkey = NamedTemporaryFile(delete=False)
-        db_pubkey.write(bytes(user[5], 'utf-8'))
-        db_pubkey.close()
+        with NamedTemporaryFile(delete=False) as db_pubkey:
+            db_pubkey.write(bytes(user[5], 'utf-8'))
         db_pubkey_fingerprint = get_fingerprint(db_pubkey.name)
         remove(db_pubkey.name)
 
@@ -428,9 +426,8 @@ class Client():
             return tools.response_render(
                 'Error: No pubkey given.',
                 http_code='400 Bad Request')
-        tmp_pubkey = NamedTemporaryFile(delete=False)
-        tmp_pubkey.write(bytes(pubkey, 'utf-8'))
-        tmp_pubkey.close()
+        with NamedTemporaryFile(delete=False) as tmp_pubkey:
+            tmp_pubkey.write(bytes(pubkey, 'utf-8'))
 
         pubkey_fingerprint = get_fingerprint(tmp_pubkey.name)
         if pubkey_fingerprint == 'Unknown':

--- a/src/server/web/CHANGELOG.md
+++ b/src/server/web/CHANGELOG.md
@@ -4,6 +4,25 @@ CHANGELOG
 CASSH Web Client
 -----
 
+1.3.0
+-----
+
+2021/05/10
+
+### New Features
+  - `LISTEN` parameter in configuration for the WEB UI (@fedegiova)
+
+1.2.0
+-----
+
+2020/05/05
+
+### New Features
+  - Allow env variables to be set instead (or in complement) of the `settings.txt` configuration file.
+
+### Changes
+  - VERSION is not necessary anymore in configuration file, hard-coded.
+
 1.1.1
 -----
 

--- a/src/server/web/Dockerfile
+++ b/src/server/web/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8
+
+WORKDIR /opt/cassh
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -U pip
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./cassh_web.py" ]

--- a/src/server/web/INSTALL.md
+++ b/src/server/web/INSTALL.md
@@ -1,0 +1,49 @@
+# INSTALL - CASSH Server WebUI
+
+## Docker
+
+```bash
+# Optionnal: Build image
+# docker build . -t nbeguier/cassh-web
+
+# Run an example web server
+docker run -it --rm \
+    -v $PWD/settings.txt.sample:/opt/cassh/settings.txt \
+    -v /etc/ssl/certs/ssl-cert-snakeoil.pem:/etc/ssl/certs/ssl-cert-snakeoil.pem:ro \
+    -v /etc/ssl/private/ssl-cert-snakeoil.key:/etc/ssl/private/ssl-cert-snakeoil.key:ro \
+    -p 8443:8443 \
+    nbeguier/cassh-web
+
+# Go to https://0.0.0.0:8443/
+
+```
+
+## From scratch
+```bash
+pip install -U pip
+pip install -r requirements.txt
+cp settings.txt.sample settings.txt
+# Edit this file
+python cassh_web.py
+
+# Go to https://0.0.0.0:8443/
+```
+
+## Configuration
+
+You can you the `settings.txt` file, but you can also override them via environment variables.
+
+
+Example:
+```bash
+docker run -it --rm \
+    -v $PWD/settings.txt.sample:/opt/cassh/settings.txt \
+    -v /etc/ssl/certs/ssl-cert-snakeoil.pem:/etc/ssl/certs/ssl-cert-snakeoil.pem:ro \
+    -v /etc/ssl/private/ssl-cert-snakeoil.key:/etc/ssl/private/ssl-cert-snakeoil.key:ro \
+    -p 8443:8443 \
+    -e LOGIN_BANNER="TEST via docker run"
+    nbeguier/cassh-web
+
+# Go to https://0.0.0.0:8443/
+
+```

--- a/src/server/web/settings.txt.sample
+++ b/src/server/web/settings.txt.sample
@@ -7,5 +7,5 @@ SSL_PUB_KEY = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 SSL_PRIV_KEY = '/etc/ssl/private/ssl-cert-snakeoil.key'
 ENCRYPTION_KEY = 'bSFEf9YNd1mXg5S5ko9NebHapQANJqFo'
 LOGIN_BANNER = 'Login LDAP/AD'
-VERSION = '1.1.1'
 DEBUG = False
+LISTEN = '0.0.0.0'

--- a/tests/test_admin_set.sh
+++ b/tests/test_admin_set.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# shellcheck disable=SC2128
+
+RESP=$(curl -s -X PATCH "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" -d "expiry=3d")
+if [ "${RESP}" == "Error: No realname option given." ]; then
+    echo "[OK] Test set expiry without realname,password"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test set expiry without realname,password: ${RESP}"
+fi
+
+RESP=$(curl -s -X PATCH -d "realname=${SYSADMIN_REALNAME}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" -d "expiry=3d")
+if [ "${RESP}" == "Error: No password option given." ]; then
+    echo "[OK] Test set expiry without password"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test set expiry without password: ${RESP}"
+fi
+
+RESP=$(curl -s -X PATCH -d "realname=${SYSADMIN_REALNAME}&password=${GUEST_B_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" -d "expiry=3d")
+if [ "${RESP}" == "Error: {'desc': 'Invalid credentials'}" ]; then
+    echo "[OK] Test set expiry with invalid credentials"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test set expiry with invalid credentials: ${RESP}"
+fi
+
+RESP=$(curl -s -X PATCH -d "realname=${GUEST_B_REALNAME}&password=${GUEST_B_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" -d "expiry=3d")
+if [ "${RESP}" == "Error: Not authorized." ]; then
+    echo "[OK] Test set expiry with unauthorized user"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test set expiry with unauthorized user: ${RESP}"
+fi
+
+RESP=$(curl -s -X PATCH -d "realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" -d "expiry=+3d")
+if [ "${RESP}" == "Error: invalid expiry." ]; then
+    echo "[OK] Test set wrong expiry for ${GUEST_B_USERNAME}"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test set wrong expiry for ${GUEST_B_USERNAME} : ${RESP}"
+fi
+
+##############################
+## ADMIN SET GUEST B EXPIRY ##
+##############################
+RESP=$(curl -s -X PATCH -d "realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" -d "expiry=3d")
+if [ "${RESP}" == "OK: expiry=3d for ${GUEST_B_USERNAME}" ]; then
+    echo "[OK] Test set expiry to 3 days for ${GUEST_B_USERNAME}"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test set expiry to 3 days for ${GUEST_B_USERNAME} : ${RESP}"
+fi
+
+RESP=$(curl -s -X POST -d "username=${GUEST_B_USERNAME}&realname=${GUEST_B_REALNAME}&password=${GUEST_B_PASSWORD}&pubkey=${GUEST_B_PUB_KEY}" "${CASSH_SERVER_URL}"/client)
+echo "${RESP}" > /tmp/test-cert
+if ssh-keygen -L -f /tmp/test-cert >/dev/null 2>&1; then
+    echo "[OK] Test signing key when changing expiry"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test signing key when changing expiry : ${RESP}"
+fi
+rm -f /tmp/test-cert


### PR DESCRIPTION
CASSH Server
-----

2.2.0
-----

2021/03/26

  - `realname` can have upper case (@fedegiova)

  - `expiry` do not require a `+`

CASSH Web Client
-----

1.3.0
-----

2021/05/10

  - `LISTEN` parameter in configuration for the WEB UI (@fedegiova)

1.2.0
-----

2020/05/05

  - Allow env variables to be set instead (or in complement) of the `settings.txt` configuration file.

  - VERSION is not necessary anymore in configuration file, hard-coded.

CASSH Client
-----

1.8.0
-----

2021/05/10

  - `expiry` do not require a `+`

  - Fix `expiry` crash (@fedegiova)