### PR TITLE
Add support for secure ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ password = xxxxxxxx
 host = ldap.domain.fr
 bind_dn = OU=User,DC=domain,DC=fr
 admin_cn = CN=Admin,OU=Group,DC=domain,DC=fr
+protocol = ldaps
 # Key in user result to get his LDAP realname
 filterstr = userPrincipalName
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -697,7 +697,8 @@ class PrincipalsSearch():
             ldap_conn, _ = tools.get_ldap_conn(
                 SERVER_OPTS['ldap_host'],
                 SERVER_OPTS['ldap_username'],
-                SERVER_OPTS['ldap_password'])
+                SERVER_OPTS['ldap_password'],
+                SERVER_OPTS['ldap_protocol'])
 
         result = dict()
 


### PR DESCRIPTION
Allow cassh to communicate with ldap using ldaps

User can choose between ldap and ldaps in the server config file

```
[ldap]
protocol = ldaps
```

if no protocol field is present in the config file, `ldap` value is the default for backward compatibility